### PR TITLE
Remove rerun-if-env-changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,5 +3,5 @@ use std::env;
 fn main() {
     let profile = env::var("PROFILE").unwrap();
     println!("cargo:rustc-env=PROFILE={profile}");
-    println!("cargo:rerun-if-env-changed=PROFILE");
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
As documented here: https://github.com/rust-lang/cargo/pull/12482
We should not be using rerun-if-env-changed here.

It causes needless rebuilds when running `cargo build` from within our binary and that happens within tokio-bin-process's [BinProcess::start_crate_name](https://docs.rs/tokio-bin-process/latest/tokio_bin_process/struct.BinProcess.html#method.start_crate_name)

However we cannot have no rerun clauses as that causes cargo to rebuild every time.
So instead we do the documented workaround of adding `rerun-if-changed=build.rs`: https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath