### PR TITLE
change timeout field from u64 to Duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,13 +179,11 @@ impl DockerCompose {
     /// Will panic if a timeout occurs.
     fn wait_for_logs(file_path: &str, services: &mut [&mut Service]) {
         // Find the service with the maximum timeout and use that
-        let timeout = Duration::from_secs(
-            services
-                .iter()
-                .map(|service| service.timeout)
-                .max()
-                .unwrap(),
-        );
+        let timeout = services
+            .iter()
+            .map(|service| service.timeout)
+            .max_by_key(|x| x.as_nanos())
+            .unwrap();
 
         // TODO: remove this check once CI docker compose is updated (probably ubuntu 22.04)
         let can_use_status_flag =
@@ -287,7 +285,7 @@ impl DockerCompose {
 pub struct Image {
     pub name: &'static str,
     pub log_regex_to_wait_for: &'static str,
-    pub timeout: u64,
+    pub timeout: Duration,
 }
 
 /// Holds the state for a running service
@@ -295,7 +293,7 @@ struct Service {
     name: String,
     log_to_wait_for: Regex,
     logs_seen: usize,
-    timeout: u64,
+    timeout: Duration,
 }
 
 impl Service {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,11 +1,12 @@
 use docker_compose_runner::{DockerCompose, Image};
 use redis::Commands;
+use std::time::Duration;
 
 #[test]
 fn test() {
     // loop multiple times to test cleanup
     for _ in 0..3 {
-        let _redis = DockerCompose::new(get_image_waiters(), |_| {}, "tests/docker-compose.yaml");
+        let _redis = DockerCompose::new(&IMAGE_WAITERS, |_| {}, "tests/docker-compose.yaml");
         let client = redis::Client::open("redis://127.0.0.1/").unwrap();
         let mut con = client.get_connection().unwrap();
         let _: () = con.set("my_key", 42).unwrap();
@@ -14,10 +15,8 @@ fn test() {
     }
 }
 
-pub fn get_image_waiters() -> &'static [Image] {
-    &[Image {
-        name: "bitnami/redis:6.2.13-debian-11-r73",
-        log_regex_to_wait_for: r"Ready to accept connections",
-        timeout: 120,
-    }]
-}
+pub const IMAGE_WAITERS: [Image; 1] = [Image {
+    name: "bitnami/redis:6.2.13-debian-11-r73",
+    log_regex_to_wait_for: r"Ready to accept connections",
+    timeout: Duration::from_secs(120),
+}];


### PR DESCRIPTION
closes https://github.com/shotover/docker-compose-runner/issues/7

get_image_waiters had to become a constant after changing the u64 to a Duration due to some funky rust constant expression interaction with lifetimes.
It makes more sense as a constant anyway though.