### PR TITLE
Move redis to dev dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
 dependencies = [
  "combine",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ description = "A small helper for running `docker-compose.yaml` files"
 
 [dependencies]
 anyhow = "1.0.70"
-redis = "0.23.3"
 regex = "1.7.0"
 serde_yaml = "0.9.21"
 subprocess = "0.2.9"
 tracing = "0.1.37"
+
+[dev-dependencies]
+redis = "0.24.0"


### PR DESCRIPTION
Redis was accidentally added as an actual dep instead of a dev dep in https://github.com/shotover/docker-compose-runner/pull/10

This PR fixes that mistake.