### PR TITLE
Release 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "docker-compose-runner"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-compose-runner"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.56"
 repository = "https://github.com/shotover/docker-compose-runner"


### PR DESCRIPTION
Just includes the non-breaking change: https://github.com/shotover/docker-compose-runner/pull/14