### PR TITLE
swap to regex-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,7 +30,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "redis",
- "regex",
+ "regex-lite",
  "serde_yaml",
  "subprocess",
  "tracing",
@@ -156,33 +147,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.2"
+name = "regex-lite"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "A small helper for running `docker-compose.yaml` files"
 
 [dependencies]
 anyhow = "1.0.70"
-regex = "1.7.0"
+regex-lite = "0.1.5"
 serde_yaml = "0.9.21"
 subprocess = "0.2.9"
 tracing = "0.1.37"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use regex::Regex;
+use regex_lite::Regex;
 use serde_yaml::Value;
 use std::collections::HashMap;
 use std::fmt::Write;


### PR DESCRIPTION
regex-lite is by the same author as the regex crate.
https://github.com/rust-lang/regex/tree/master/regex-lite#motivation

It compiles in 0.73s instead of 1.93s and takes up 94KB in the compiled binary instead of 565KB
Reference https://github.com/rust-lang/regex/tree/master/regex-lite#motivation

This does come with some cost to regex performance, however, this library uses regex solely while waiting for a docker instance to come up, as such a slower regex wont slow us down as we are already waiting around.
