### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "docker-compose-runner"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docker-compose-runner"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 repository = "https://github.com/shotover/docker-compose-runner"
 license = "Apache-2.0"


### PR DESCRIPTION
Releasing as breaking change due to removal of legacy codepath in https://github.com/shotover/docker-compose-runner/pull/19